### PR TITLE
Add some `Tensor.Op`s and make it easy to run them.

### DIFF
--- a/manifest.savi
+++ b/manifest.savi
@@ -1,6 +1,9 @@
 :manifest lib Tensor
   :sources "src/*.savi"
 
+  :dependency Map v0
+    :from "github:savi-lang/Map"
+
 :manifest bin "spec"
   :copies Tensor
   :sources "spec/*.savi"
@@ -10,9 +13,6 @@
     :depends on Map
     :depends on Time
     :depends on Timer
-
-  :transitive dependency Map v0
-    :from "github:savi-lang/Map"
 
   :transitive dependency Time v0
     :from "github:savi-lang/Time"

--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -3,4 +3,7 @@
     Spec.Process.run(env, [
       Spec.Run(Tensor.Spec).new(env)
       Spec.Run(Tensor.Graph.Spec).new(env)
+      Spec.Run(Tensor.Op.Const.Spec).new(env)
+      Spec.Run(Tensor.Op.MatMul.Spec).new(env)
+      Spec.Run(Tensor.Op.Softmax.Spec).new(env)
     ])

--- a/spec/Tensor.Graph.Spec.savi
+++ b/spec/Tensor.Graph.Spec.savi
@@ -21,18 +21,34 @@
           .set_attr_tensor!("value", b_value)
           .finish!
       )
-      product = graph.new_operation("MatMul", "example") -> (builder |
+      product1 = graph.new_operation("MatMul", "product1") -> (builder |
         builder
           .add_input(a.output(0))
           .add_input(b.output(0))
           .finish!
       )
+      product2 = graph.new_operation("MatMul", "product2") -> (builder |
+        builder
+          .add_input(a.output(0))
+          .add_input(b.output(0))
+          .set_attr_bool("transpose_a", True)
+          .finish!
+      )
 
-      result = session.open!.hacky_temporary_run!(product)
-
+      result = session.compute!(product1.output(0))
       assert: result.as!(Tensor(F64)).into_array == [
         1.0 * 5.0 + 2.0 * 7.0, 1.0 * 6.0 + 2.0 * 8.0 // row1⋅col1, row1⋅col2
         3.0 * 5.0 + 4.0 * 7.0, 3.0 * 6.0 + 4.0 * 8.0 // row2⋅col1, row2⋅col2
+      ]
+
+      results = session.compute_many!([product1.output(0), product2.output(0)])
+      assert: results[product1.output(0)]!.as!(Tensor(F64)).into_array == [
+        1.0 * 5.0 + 2.0 * 7.0, 1.0 * 6.0 + 2.0 * 8.0 // row1⋅col1, row1⋅col2
+        3.0 * 5.0 + 4.0 * 7.0, 3.0 * 6.0 + 4.0 * 8.0 // row2⋅col1, row2⋅col2
+      ]
+      assert: results[product2.output(0)]!.as!(Tensor(F64)).into_array == [
+        1.0 * 5.0 + 3.0 * 7.0, 1.0 * 6.0 + 3.0 * 8.0 // col1⋅col1, col1⋅col2
+        2.0 * 5.0 + 4.0 * 7.0, 2.0 * 6.0 + 4.0 * 8.0 // col2⋅col1, col2⋅col2
       ]
     |
       graph.errors.each -> (error | @env.err.print(error.message))

--- a/spec/Tensor.Op.Const.Spec.savi
+++ b/spec/Tensor.Op.Const.Spec.savi
@@ -1,0 +1,14 @@
+:class Tensor.Op.Const.Spec
+  :is Spec
+  :const describes: "Tensor.Op.Const"
+
+  :it "emits a constant tensor value"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.const!("example"
+          Tensor(F64).from_array([1, 2, 3, 4])
+        )
+      )
+
+      assert: result.as!(Tensor(F64)).into_array == [1, 2, 3, 4]
+    ))

--- a/spec/Tensor.Op.MatMul.Spec.savi
+++ b/spec/Tensor.Op.MatMul.Spec.savi
@@ -1,0 +1,90 @@
+:class Tensor.Op.MatMul.Spec
+  :is Spec
+  :const describes: "Tensor.Op.MatMul"
+
+  :fun non f64_2x2(a, b, c, d)
+    Tensor(F64).from_array([a, b, c, d]).try_reshape([2, 2])
+
+  :it "computes matrix multiplication"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.matmul!("example"
+          g.const!("A", @f64_2x2(1.0, 2.0, 3.0, 4.0))
+          g.const!("B", @f64_2x2(5.0, 6.0, 7.0, 8.0))
+        )
+      )
+
+      assert: result.as!(Tensor(F64)).into_array == [
+        1.0 * 5.0 + 2.0 * 7.0, 1.0 * 6.0 + 2.0 * 8.0 // Arow1⋅Bcol1, Arow1⋅Bcol2
+        3.0 * 5.0 + 4.0 * 7.0, 3.0 * 6.0 + 4.0 * 8.0 // Arow2⋅Bcol1, Arow2⋅Bcol2
+      ]
+    ))
+
+  :it "computes matrix multiplication with the first matrix transposed"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.matmul_with_a_transposed!("example"
+          g.const!("A", @f64_2x2(1.0, 2.0, 3.0, 4.0))
+          g.const!("B", @f64_2x2(5.0, 6.0, 7.0, 8.0))
+        )
+      )
+
+      assert: result.as!(Tensor(F64)).into_array == [
+        1.0 * 5.0 + 3.0 * 7.0, 1.0 * 6.0 + 3.0 * 8.0 // Acol1⋅Bcol1, Acol1⋅Bcol2
+        2.0 * 5.0 + 4.0 * 7.0, 2.0 * 6.0 + 4.0 * 8.0 // Acol2⋅Bcol1, Acol2⋅Bcol2
+      ]
+    ))
+
+  :it "computes matrix multiplication with the second matrix transposed"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.matmul_with_b_transposed!("example"
+          g.const!("A", @f64_2x2(1.0, 2.0, 3.0, 4.0))
+          g.const!("B", @f64_2x2(5.0, 6.0, 7.0, 8.0))
+        )
+      )
+
+      assert: result.as!(Tensor(F64)).into_array == [
+        1.0 * 5.0 + 2.0 * 6.0, 1.0 * 7.0 + 2.0 * 8.0 // Arow1⋅Brow1, Arow1⋅Brow2
+        3.0 * 5.0 + 4.0 * 6.0, 3.0 * 7.0 + 4.0 * 8.0 // Arow2⋅Brow1, Arow2⋅Brow2
+      ]
+    ))
+
+  :it "computes matrix multiplication with both matrices transposed"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.matmul_with_both_transposed!("example"
+          g.const!("A", @f64_2x2(1.0, 2.0, 3.0, 4.0))
+          g.const!("B", @f64_2x2(5.0, 6.0, 7.0, 8.0))
+        )
+      )
+
+      assert: result.as!(Tensor(F64)).into_array == [
+        1.0 * 5.0 + 3.0 * 6.0, 1.0 * 7.0 + 3.0 * 8.0 // Acol1⋅Brow1, Acol1⋅Brow2
+        2.0 * 5.0 + 4.0 * 6.0, 2.0 * 7.0 + 4.0 * 8.0 // Acol2⋅Brow1, Acol2⋅Brow2
+      ]
+    ))
+
+  :it "complains when one of the inputs is a scalar (rank 0 tensor)"
+    _WithGraphHelper.run(@env, False) -> (g, session |
+      assert error: g.matmul!("example"
+        g.const!("A", Tensor(F64).scalar(99))
+        g.const!("B", @f64_2x2(5.0, 6.0, 7.0, 8.0))
+      )
+    )
+
+  :it "complains when one of the inputs is a vector (rank 1 tensor)"
+    _WithGraphHelper.run(@env, False) -> (g, session |
+      assert error: g.matmul!("example"
+        g.const!("A", Tensor(F64).from_array([1, 2, 3, 4]))
+        g.const!("B", @f64_2x2(5.0, 6.0, 7.0, 8.0))
+      )
+    )
+
+  :it "complains when one of the inputs has a rank higher 2"
+    _WithGraphHelper.run(@env, False) -> (g, session |
+      assert error: g.matmul!("example"
+        g.const!("A", @f64_2x2(1.0, 2.0, 3.0, 4.0).try_reshape([2, 1, 2]))
+        g.const!("B", @f64_2x2(5.0, 6.0, 7.0, 8.0))
+      )
+    )

--- a/spec/Tensor.Op.Softmax.Spec.savi
+++ b/spec/Tensor.Op.Softmax.Spec.savi
@@ -1,0 +1,60 @@
+:class Tensor.Op.Softmax.Spec
+  :is Spec
+  :const describes: "Tensor.Op.Softmax"
+
+  :it "computes the softmax function of a vector (tensor rank 1)"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.softmax!("example"
+          g.const!("input", Tensor(F64).from_array([1, 2, 3, 4, 5]))
+        )
+      )
+
+      assert: result.as!(Tensor(F64)).into_array == [
+        0.01165623095603961
+        0.031684920796124276
+        0.08612854443626873
+        0.23412165725273662
+        0.6364086465588309
+      ]
+    ))
+
+  :it "complains when applied to a scalar (rank 0 tensor)"
+    _WithGraphHelper.run(@env, False) -> (g, session |
+      assert error: (
+        g.softmax!("example"
+          g.const!("input", Tensor(F64).scalar(99))
+        )
+      )
+    )
+
+  :it "when applied to a higher rank, computes each inner row separately"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.softmax!("example"
+          g.const!("input"
+            Tensor(F64).from_array([
+              1, 2, 3
+              1, 2, 0 // with implicit bias, this is equivalent to 2, 3, 1
+
+              4, 5, 6 // with implicit bias, this is equivalent to 1, 2, 3
+              4, 5, 0 // but here the pattern changes, as 0 is far from 4 & 5
+
+              7, 8, 9 // and this is also equivalent to 1, 2, 3
+              7, 8, 0 // and this 0 is even father from 7 & 8
+            ]).try_reshape([3, 2, 3])
+          )
+        )
+      )
+
+      assert: result.as!(Tensor(F64)).into_array == [
+        0.09003057317038046, 0.2447284710547976, 0.6652409557748219
+        0.24472847105479759, 0.6652409557748218, 0.09003057317038045
+
+        0.09003057317038046, 0.2447284710547976, 0.6652409557748219
+        0.2676231541498623,  0.7274751568004648, 0.004901689049672922
+
+        0.09003057317038046, 0.2447284710547976, 0.6652409557748219
+        0.26887548158545244, 0.7308793357119101, 0.00024518270263755956
+      ]
+    ))

--- a/spec/_WithGraphHelper.savi
+++ b/spec/_WithGraphHelper.savi
@@ -1,0 +1,16 @@
+:struct _WithGraphHelper
+  :let graph: Tensor.Graph.new
+  :let session: Tensor.Graph.Session.new(@graph)
+  :copies Tensor.Graph.Helper.Methods
+
+  :fun non run(env Env, print_errors = True)
+    graph = Tensor.Graph.new
+    g = Tensor.Graph.Helper.new(graph)
+    session = Tensor.Graph.Session.new(graph)
+
+    yield (g, session)
+
+    if print_errors (
+      graph.errors.each -> (error | env.err.print(error.message))
+      session.errors.each -> (error | env.err.print(error.message))
+    )

--- a/src/Tensor.Graph.Helper.savi
+++ b/src/Tensor.Graph.Helper.savi
@@ -1,0 +1,34 @@
+:struct Tensor.Graph.Helper
+  :let graph Tensor.Graph
+  :new (@graph)
+  :copies Tensor.Graph.Helper.Methods
+
+:trait Tensor.Graph.Helper.Methods
+  :fun graph @->(Tensor.Graph)
+
+  ///
+  // Value Sources
+
+  :fun ref const!(name, value)
+    Tensor.Op.Const.new!(@graph, name, value)
+
+  ///
+  // Unary Operations
+
+  :fun ref softmax!(name, input)
+    Tensor.Op.Softmax.new!(@graph, name, input)
+
+  ///
+  // Binary Operations
+
+  :fun ref matmul!(name, a, b)
+    Tensor.Op.MatMul.new!(@graph, name, a, b, False, False)
+
+  :fun ref matmul_with_a_transposed!(name, a, b)
+    Tensor.Op.MatMul.new!(@graph, name, a, b, True, False)
+
+  :fun ref matmul_with_b_transposed!(name, a, b)
+    Tensor.Op.MatMul.new!(@graph, name, a, b, False, True)
+
+  :fun ref matmul_with_both_transposed!(name, a, b)
+    Tensor.Op.MatMul.new!(@graph, name, a, b, True, True)

--- a/src/Tensor.Graph.Input.savi
+++ b/src/Tensor.Graph.Input.savi
@@ -1,12 +1,12 @@
-:struct Tensor.Graph.Input
-  :let operation Tensor.Graph.Operation
+:struct box Tensor.Graph.Input
+  :let op Tensor.Graph.Operation
   :let index USize
-  :new (@operation, @index)
+  :new box (@op, @index)
 
   :fun _to_ffi
-    _FFI.Input._new(@operation._ptr, @index.i32)
+    _FFI.Input._new(@op._ptr, @index.i32)
 
 :struct _FFI.Input
-  :let operation_ptr CPointer(_FFI.Operation)
-  :let index I32
-  :new _new(@operation_ptr, @index)
+  :let _op_ptr CPointer(_FFI.Operation)
+  :let _index I32
+  :new _new(@_op_ptr, @_index)

--- a/src/Tensor.Graph.Operation.savi
+++ b/src/Tensor.Graph.Operation.savi
@@ -22,9 +22,18 @@
   :new _new(@graph, op_type String, oper_name String)
     @_ptr = @_ffi.new(@graph._ptr, op_type.cpointer, oper_name.cpointer)
 
-  :fun ref add_input(from_output Tensor.Graph.Output)
+  :fun ref add_input(can_output Tensor.Graph.CanOutput)
     return @ if @_ptr.is_null
-    @_ffi.add_input(@_ptr, from_output._to_ffi)
+    @_ffi.add_input(@_ptr, can_output.output._to_ffi)
+    @
+
+  :fun ref set_attr_bool(attr_name String, value Bool)
+    return @ if @_ptr.is_null
+    @_ffi.set_attr_bool(
+      @_ptr
+      attr_name.cstring
+      value.u8
+    )
     @
 
   :fun ref set_attr_type(attr_name String, type_code I32)
@@ -79,6 +88,13 @@
   //   input _FFI.Output
   // ) None
   //   :foreign_name TF_AddOutput
+
+  :ffi set_attr_bool(
+    ptr CPointer(@)
+    attr_name CPointer(U8)
+    value U8
+  ) None
+    :foreign_name TF_SetAttrBool
 
   :ffi set_attr_type(
     ptr CPointer(@)

--- a/src/Tensor.Graph.Output.savi
+++ b/src/Tensor.Graph.Output.savi
@@ -1,12 +1,23 @@
-:struct Tensor.Graph.Output
-  :let operation Tensor.Graph.Operation
+:trait box Tensor.Graph.CanOutput
+  :fun output Tensor.Graph.Output
+
+:struct box Tensor.Graph.Output
+  :let op Tensor.Graph.Operation
   :let index USize
-  :new (@operation, @index)
+  :new box (@op, @index)
+
+  :is Tensor.Graph.CanOutput
+  :fun output: @
+
+  :fun hash USize: @op._ptr.address.hash.bit_xor(@index.hash)
+  :fun "=="(that @'box) Bool
+    @op._ptr.address == that.op._ptr.address
+    && @index == that.index
 
   :fun _to_ffi
-    _FFI.Output._new(@operation._ptr, @index.i32)
+    _FFI.Output._new(@op._ptr, @index.i32)
 
-:struct _FFI.Output
-  :let operation_ptr CPointer(_FFI.Operation)
-  :let index I32
-  :new _new(@operation_ptr, @index)
+:struct box _FFI.Output
+  :let _op_ptr CPointer(_FFI.Operation)
+  :let _index I32
+  :new box _new(@_op_ptr, @_index)

--- a/src/Tensor.Graph.Session.savi
+++ b/src/Tensor.Graph.Session.savi
@@ -23,6 +23,8 @@
     error!
 
   :fun ref open!
+    return if @_ptr.is_not_null
+
     target = "local" // TODO: add mechanism for remote execution, respecting object capability security
 
     options_ptr = @_ffi_options.new
@@ -39,19 +41,56 @@
 
   // TODO: Add a mechanism for partial runs (TF_SessionPRun and friends)
 
-  :fun ref hacky_temporary_run!(op Tensor.Graph.Operation) Tensor.Any
-    // TODO: accept inputs as parameters?
-    target_ops = [op] // TODO: accept target operation list as a param
-    outputs = [op.output(0)] // TODO: accept output list as a param
+  :fun ref compute!(
+    can_output Tensor.Graph.CanOutput
+  ) Tensor.Any
+    @open!
 
+    // TODO: accept input list as a parameter
+    output = can_output.output
+    output_ffi = output._to_ffi
+    target_op_ptr = output.op._ptr
+    output_tensor_ptr = CPointer(_FFI.Tensor).null
+
+    @_ffi.run(
+      @_ptr
+      CPointer(_FFI.Buffer).null
+
+      // Inputs
+      CPointer(_FFI.Input).null
+      CPointer(CPointer(_FFI.Tensor)).null
+      0
+
+      // Outputs
+      stack_address_of_variable output_ffi
+      stack_address_of_variable output_tensor_ptr
+      1
+
+      // Target Operations
+      stack_address_of_variable target_op_ptr
+      1
+
+      CPointer(_FFI.Buffer).null
+      @_status_ptr
+    )
+    @_check_status!
+
+    _FFI.Tensor._adopt_ownership_of(output_tensor_ptr)
+
+  :fun ref compute_many!(
+    outputs Array(Tensor.Graph.Output)'box // TODO: use CanOutput instead of just Output
+  )
+    @open!
+
+    // TODO: accept input list as a parameter
     output_ffis = Array(_FFI.Output).new(outputs.size)
-    outputs.each -> (output | output_ffis << output._to_ffi)
-
     output_tensor_ptrs = Array(CPointer(_FFI.Tensor)).new(outputs.size)
-    output_tensor_ptrs << CPointer(_FFI.Tensor).null
-
-    target_op_ptrs = Array(CPointer(_FFI.Operation)).new(target_ops.size)
-    target_ops.each -> (op | target_op_ptrs << op._ptr)
+    target_op_ptrs = Array(CPointer(_FFI.Operation)).new(outputs.size)
+    outputs.each -> (output |
+      output_ffis << output._to_ffi
+      output_tensor_ptrs << CPointer(_FFI.Tensor).null
+      target_op_ptrs << output.op._ptr
+    )
 
     @_ffi.run(
       @_ptr
@@ -76,8 +115,15 @@
     )
     @_check_status!
 
-    // TODO: Return list of outputs?
-    _FFI.Tensor._adopt_ownership_of(output_tensor_ptrs[0]!)
+    results = Map(Tensor.Graph.Output, Tensor.Any).new(outputs.size)
+    outputs.each_with_index -> (output, index |
+      try (
+        results[output] = _FFI.Tensor._adopt_ownership_of(
+          output_tensor_ptrs[index]!
+        )
+      )
+    )
+    results
 
 :module _FFI.Session.Options
   :ffi new CPointer(@)

--- a/src/Tensor.Op.Const.savi
+++ b/src/Tensor.Op.Const.savi
@@ -1,0 +1,15 @@
+:: Produces a constant `Tensor` value (a fixed value in the `Tensor.Graph`,
+:: which doesn't come from an input value supplied to the graph at runtime).
+::
+:: If you want to supply a value at runtime, use `Tensor.Op.Placeholder`.
+:struct box Tensor.Op.Const
+  :is Tensor.Op
+  :fun non new!(graph Tensor.Graph, name
+    value
+  )
+    @_new(graph.new_operation("Const", name) -> (builder |
+      builder
+        .set_attr_tensor!("value", value)
+        .set_attr_type("dtype", value.element_type_code)
+        .finish!
+    ))

--- a/src/Tensor.Op.MatMul.savi
+++ b/src/Tensor.Op.MatMul.savi
@@ -1,0 +1,62 @@
+:: Computes matrix multiplication on the two input matrices (`A` and `B`).
+::
+:: Because matrices are expected, the two input tensors must be of rank 2,
+:: else an error will be raised indicating the invalid arguments.
+::
+:: A matrix can be thought of as a linear transformation function (that is,
+:: a function that can take vector values and transform them in a linear way).
+:: See <https://mathinsight.org/matrices_linear_transformations>
+::
+:: Under this thinking, matrix multiplication can be thought of as the
+:: composition of two given linear transformation functions such that we
+:: produce a new linear transformation function which can transform its inputs
+:: in the same way that they would be transformed if the two original
+:: linear transformation functions were applied, one after the other.
+::
+:: Note that matrix multiplication is *not* commutative like the multiplication
+:: of scalar values is. Rather, the order of terms matters: `AB` != `BA`.
+:: If you think of them as linear transformations, this corresponds to the
+:: fact that you'll get different results based on the order in which you
+:: apply the individual transformations.
+::
+:: In computer graphics, games, and other simulations, matrix multiplication
+:: is often used to "stack" coordinate transformations on top of one another,
+:: with the resulting matrix being a transformation you can apply as a single
+:: operation that effectively applies the whole stack of transformation.
+:: If you're familiar with such systems, you know that the order of applying
+:: transformations matters there as well, and for the same reasons.
+::
+:: In machine learning, matrix multiplication is also used to "stack" or "chain"
+:: transformations in a model. Often, one of the transformations being stacked
+:: is a "learned" transformation (its matrix cell values being model weights).
+::
+:: This component of model architecture effectively gives the model a way
+:: to learn an appropriate (linear) transformation function that will
+:: play a role in transforming the input data into some desirable output data.
+::
+:: However, note that directly stacking multiple learned linear transformations
+:: is not productive, and is a waste of model weights and computational power.
+:: Recall that any two matrices (linear transformations) can be composed via
+:: matrix multiplication into a single equivalent linear transformation.
+:: Therefore, no additional learnable behaviors can be introduced by composing
+:: two directly-stacked layers of learnable linear transformations - all the
+:: same behaviors can emerge with just one learnable linear transformation.
+:: To make the stacking productive of new emergent behaviors, you need to
+:: include some nonlinear transformation in between the learned linear ones.
+:struct box Tensor.Op.MatMul
+  :is Tensor.Op
+
+  :fun non new!(graph Tensor.Graph, name
+    a
+    b
+    transpose_a Bool = False
+    transpose_b Bool = False
+  )
+    @_new(graph.new_operation("MatMul", name) -> (builder |
+      builder
+        .add_input(a)
+        .add_input(b)
+        .set_attr_bool("transpose_a", transpose_a)
+        .set_attr_bool("transpose_b", transpose_b)
+        .finish!
+    ))

--- a/src/Tensor.Op.Softmax.savi
+++ b/src/Tensor.Op.Softmax.savi
@@ -1,0 +1,61 @@
+:: The softmax function takes a set of input values and scales them nonlinearly
+:: to produce a set of output values that have the following useful properties:
+::
+:: - They are normalized (they are all are between zero and one).
+:: - When they are all added together the sum is one.
+:: - The highest input values correspond to the highest output values.
+:: - The distance between the highest value and the second-highest value
+::   is magnified in the output, making the highest value "stand out" more.
+::
+:: The first two properties make the output look like a probability distribution
+:: with the sum of all probabilities adding up to one (i.e. a 100% chance).
+::
+:: The third property makes sure the distribution has an intuitive relationship
+:: to the input values - a reasonable way of converting to probabilities.
+::
+:: The fourth property indicates a nonlinearity in the transformation,
+:: and it comes from the fact that this function is defined in terms
+:: of exponential growth (this is what "accentuates" the highest value).
+:: See <https://deepai.org/machine-learning-glossary-and-terms/softmax-layer>
+::
+:: So why do we call it a "softmax" function? Well, that's because it's a
+:: little bit like as if we had simply selected the maximum value and set
+:: every other output value to zero - that would be a "hard maximum" function.
+:: But what we're doing is softer than that! No matter how far any given input
+:: value is below the maximum, it's never assigned an output value of zero -
+:: it always gets at least a little slice of the overall pie.
+::
+:: So why do we prefer a "soft" max over a "hard" max in machine learning?
+:: Well, chiefly because: in order for the model to learn, we need to be able
+:: to calculate a gradient descent for it, which means all the operations that
+:: compose it need to be differentiable (we need to be able to calculate a
+:: meaningful derivative). And a "hard" max function is really a piecewise
+:: function that thus has undifferentiable cliffs at the piecewise boundaries.
+::
+:: To get an intuition for this, picture the "hotter or colder" game that
+:: children often play, in which at every step the seeker is told how "hot" or
+:: "cold" they currently are, and whether they are "getting hotter" or "colder"
+:: as they move about, seeking the hidden goal. In other words, they get
+:: information about their "derivative" in a kind of gradient descent algorithm.
+:: How much harder would it be for the seeker to find their goal if they were
+:: only told "yes" or "no" at each step with no information whether they are
+:: nearing their goal or receding from it! If the goal were an infinitesimal
+:: point in space, they would neither reach it nor have any decidable way
+:: of approaching it without this information.
+::
+:: This is why we use a "soft" max instead of a "hard" max for learning:
+:: no matter how near or far you are from the goal in the problem space,
+:: you always learn something about how to approach it (a vector in that space).
+:: While the system that produces the input values for the softmax function
+:: is being adjusted via the learning process, it can see meaningful results.
+:struct box Tensor.Op.Softmax
+  :is Tensor.Op
+
+  :fun non new!(graph Tensor.Graph, name
+    logits
+  )
+    @_new(graph.new_operation("Softmax", name) -> (builder |
+      builder
+        .add_input(logits)
+        .finish!
+    ))

--- a/src/Tensor.Op.savi
+++ b/src/Tensor.Op.savi
@@ -1,0 +1,6 @@
+:trait box Tensor.Op
+  :let op Tensor.Graph.Operation
+  :new box _new(@op)
+
+  :is Tensor.Graph.CanOutput
+  :fun output: @op.output(0)

--- a/src/Tensor.savi
+++ b/src/Tensor.savi
@@ -1,6 +1,7 @@
 :trait Tensor.Any
   :let _ptr CPointer(_FFI.Tensor)
   :let _ptr_is_owned Bool
+  :fun element_type_code I32
 
 :class Tensor(T Numeric(T)'val) // TODO: Exclude non-machine word implementers of the Numeric trait
   :is Tensor.Any
@@ -25,6 +26,23 @@
   //     dimensions.size.i32
   //     T.byte_width.usize * total_element_count
   //   )
+
+  :new scalar(value T)
+    @_ptr_is_owned = True
+    @_ptr = @_ffi.allocate(
+      _FFI.DataType(T).code
+      CPointer(U64).null
+      0
+      T.byte_width.usize
+    )
+
+    _FFI.memcpy(
+      _FFI.Tensor.data(@_ptr)
+      _FFI.Cast(CPointer(T), CPointer(U8)).pointer(
+        stack_address_of_variable value
+      )
+      T.byte_width.usize
+    )
 
   :new from_array(data Array(T)'box)
     data_count_u64 = data.size.u64


### PR DESCRIPTION
This commit adds the first few encapsulated `Tensor.Op`s, including meaningful tests and documentation for each one. Each is a convenience layer around `Tensor.Graph.Operation`.

The ops so far are:

- `Tensor.Op.Const`
- `Tensor.Op.MatMul`
- `Tensor.Op.Softmax`