### PR TITLE
More convenient interface for `Tensor.Graph.Helper.slice!` method.

### DIFF
--- a/spec/Tensor.Op.Slice.Spec.savi
+++ b/spec/Tensor.Op.Slice.Spec.savi
@@ -24,8 +24,8 @@
               65, 66, 67, 68, 69
             ]).try_reshape([3, 4, 5])
           )
-          g.const!("begin_indices", Tensor(I32).from_array([1, 2, 1]))
-          g.const!("output_shape",  Tensor(I32).from_array([2, 2, 3]))
+          [1, 2, 1]
+          [2, 2, 3]
         )
       )
 
@@ -61,8 +61,8 @@
               65, 66, 67, 68, 69
             ]).try_reshape([3, 4, 5])
           )
-          g.const!("begin_indices", Tensor(I32).from_array([1, 2, 1]))
-          g.const!("output_shape",  Tensor(I32).from_array([3, 2, 3]))
+          [1, 2, 1]
+          [3, 2, 3]
           // (since we started at index 1 in the first dimension,
           // an output shape with size 3 in that dimension is out of bounds)
         )

--- a/src/Tensor.Graph.Helper.savi
+++ b/src/Tensor.Graph.Helper.savi
@@ -66,7 +66,22 @@
   :fun ref pack!(name, inputs, axis USize = 0)
     Tensor.Op.Pack.new!(@graph, name, inputs, axis)
 
-  :fun ref slice!(name, input, begin_indices, output_shape)
+  :fun ref slice!(
+    name
+    input
+    begin_indices Array(USize)
+    output_shape Array(USize)
+  )
+    @slice_dynamic!(name, input
+      @const!("\(name).begin_indices"
+        Tensor(I64).generate(begin_indices.size) -> (i | begin_indices[i]!.i64!)
+      )
+      @const!("\(name).output_shape"
+        Tensor(I64).generate(output_shape.size) -> (i | output_shape[i]!.i64!)
+      )
+    )
+
+  :fun ref slice_dynamic!(name, input, begin_indices, output_shape)
     Tensor.Op.Slice.new!(@graph, name, input, begin_indices, output_shape)
 
   ///


### PR DESCRIPTION
Now this method will automatically create constants for you, from the simple array of numbers you supply.

If you want the old behavior of allowing non-constant inputs for these operands, use `Tensor.Graph.Helper.slice_dynamic!`.