### PR TITLE
Add `Tensor.Op.Random` operations and `Tensor.Gen.Random` to assist.

### DIFF
--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -3,6 +3,11 @@
     Spec.Process.run(env, [
       Spec.Run(Tensor.Spec).new(env)
       Spec.Run(Tensor.Graph.Spec).new(env)
+
+      ///
+      // Tensor.Op specs
+
+      Spec.Run(Tensor.Op.Add.Spec).new(env)
       Spec.Run(Tensor.Op.Bitcast.Spec).new(env)
       Spec.Run(Tensor.Op.Cast.Spec).new(env)
       Spec.Run(Tensor.Op.Const.Spec).new(env)
@@ -11,8 +16,14 @@
       Spec.Run(Tensor.Op.Logical.Spec).new(env)
       Spec.Run(Tensor.Op.MatMul.Spec).new(env)
       Spec.Run(Tensor.Op.Pack.Spec).new(env)
+      Spec.Run(Tensor.Op.Random.Spec).new(env)
       Spec.Run(Tensor.Op.Reshape.Spec).new(env)
       Spec.Run(Tensor.Op.Select.Spec).new(env)
       Spec.Run(Tensor.Op.Slice.Spec).new(env)
       Spec.Run(Tensor.Op.Softmax.Spec).new(env)
+
+      ///
+      // Tensor.Gen specs
+
+      Spec.Run(Tensor.Gen.Random.Spec).new(env)
     ])

--- a/spec/Tensor.Gen.Random.Spec.savi
+++ b/spec/Tensor.Gen.Random.Spec.savi
@@ -1,0 +1,29 @@
+:class Tensor.Gen.Random.Spec
+  :is Spec
+  :const describes: "Tensor.Gen.Random"
+
+  :it "raises its internal counter with each graph node that uses it"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      random = g.gen_random!("random"
+        g.const!("seed", Tensor(U32).from_array([2, 3]))
+      )
+      example1 = g.random_uniform!("example1", random, Tensor(F64), [])
+      example2 = g.random_uniform!("example2", random, Tensor(F64), [])
+      example3 = g.random_uniform!("example3", random, Tensor(F64), [])
+      example4 = g.random_uniform!("example4", random, Tensor(F64), [])
+      example5 = g.random_uniform!("example5", random, Tensor(F64), [])
+
+      assert: [
+        session.compute!(example1).as!(Tensor(F64)).into_array.first!
+        session.compute!(example2).as!(Tensor(F64)).into_array.first!
+        session.compute!(example3).as!(Tensor(F64)).into_array.first!
+        session.compute!(example4).as!(Tensor(F64)).into_array.first!
+        session.compute!(example5).as!(Tensor(F64)).into_array.first!
+      ] == [
+        0.398508191067887150
+        0.765757677912869900
+        0.624153601512746500
+        0.913356627721398900
+        0.007108289495397546
+      ]
+    ))

--- a/spec/Tensor.Op.Add.Spec.savi
+++ b/spec/Tensor.Op.Add.Spec.savi
@@ -1,0 +1,35 @@
+:class Tensor.Op.Add.Spec
+  :is Spec
+  :const describes: "Tensor.Op.Add"
+
+  :it "computes arithmetic addition"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.add!("example"
+          g.const!("x", Tensor(I32).from_array([1, 2, 3, 4]))
+          g.const!("y", Tensor(I32).from_array([5, 6, 7, 8]))
+        )
+      )
+
+      assert: result.as!(Tensor(I32)).into_array == [6, 8, 10, 12]
+    ))
+
+  :it "can broadcast smaller sizes/shapes across larger sizes/shapes"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.add!("example"
+          g.const!("x", Tensor(I32).from_array([-1, -3, -5]))
+          g.const!("y", Tensor(I32).from_array([
+            1, 2, 3
+            4, 5, 6
+            7, 8, 9
+          ]).try_reshape([3, 3]))
+        )
+      )
+
+      assert: result.as!(Tensor(I32)).into_array == [
+        0, -1, -2
+        3,  2,  1
+        6,  5,  4
+      ]
+    ))

--- a/spec/Tensor.Op.Random.Spec.savi
+++ b/spec/Tensor.Op.Random.Spec.savi
@@ -1,0 +1,87 @@
+:class Tensor.Op.Random.Spec
+  :is Spec
+  :const describes: "Tensor.Op.Random"
+
+  :fun random!(g Tensor.Graph.Helper.Methods)
+    g.gen_random!("random"
+      g.const!("seed", Tensor(U32).from_array([2, 3]))
+    )
+
+  :it "generates random floating-point values between zero and one"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.random_uniform!("example", @random!(g), Tensor(F64), [5, 3])
+      )
+
+      assert: result.shape_into_array == [5, 3]
+      assert: result.as!(Tensor(F64)).into_array == [
+        0.398508191067887150, 0.732788935422899800, 0.772497775924872600
+        0.011093940016129400, 0.397627388101850600, 0.920265260249592700
+        0.078954885901334040, 0.794863860646023000, 0.738741301280144700
+        0.033675519199442006, 0.109785841235917390, 0.434643886432106300
+        0.315942563326273130, 0.829186890989337000, 0.945693221173083500
+      ]
+    ))
+
+  :it "generates random integer values"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.random_uniform_integers!("example", @random!(g), Tensor(U32), [5, 3])
+      )
+
+      assert: result.shape_into_array == [5, 3]
+      assert: result.as!(Tensor(U32)).into_array == [
+        4078329930,  536687091,  396081536
+        3825742130, 2525781030, 2696759281
+        2342530416, 3604535639, 2584108206
+        2302558966, 3643717992,  281455550
+        697385830,   852288488, 1222424515
+      ]
+    ))
+
+  :it "generates random integer values within a given bounds"
+    _WithGraphHelper.run(@env) -> (g, session | assert no_error: (
+      result = session.compute!(
+        g.random_uniform_bounded_integers!("example", @random!(g)
+          Tensor(I32)
+          [5, 12]
+          Tensor(I32).scalar(0)
+          Tensor(I32).scalar(10)
+        )
+      )
+
+      assert: result.shape_into_array == [5, 12]
+      assert: result.as!(Tensor(I32)).into_array == [
+        0, 1, 6, 0, 0, 1, 6, 9, 6, 6, 2, 0
+        0, 8, 5, 3, 0, 9, 5, 9, 6, 6, 7, 6
+        5, 9, 7, 8, 7, 7, 9, 8, 7, 9, 5, 3
+        4, 1, 5, 7, 6, 0, 7, 7, 0, 3, 8, 8
+        3, 2, 2, 8, 0, 5, 2, 6, 3, 8, 3, 1
+      ]
+    ))
+
+  :it "can't generate uniform floating-point values with an integer type"
+    _WithGraphHelper.run(@env, False) -> (g, session |
+      assert error: (
+        g.random_uniform!("example", @random!(g), Tensor(I32), [5, 3])
+      )
+    )
+
+  :it "can't generate uniform integer values with a floating-point type"
+    _WithGraphHelper.run(@env, False) -> (g, session |
+      assert error: (
+        g.random_uniform_integers!("example", @random!(g), Tensor(F64), [5, 3])
+      )
+    )
+
+  :it "can't generate uniform bounded integer values with a floating-point type"
+    _WithGraphHelper.run(@env, False) -> (g, session |
+      assert error: (
+        g.random_uniform_bounded_integers!("example", @random!(g)
+          Tensor(F64)
+          [5, 3]
+          Tensor(F64).scalar(0)
+          Tensor(F64).scalar(10)
+        )
+      )
+    )

--- a/spec/Tensor.Spec.savi
+++ b/spec/Tensor.Spec.savi
@@ -2,8 +2,14 @@
   :is Spec
   :const describes: "Tensor"
 
-  :it "creates a 1-dimensional tensor from an array"
+  :it "creates a 1-dimensional tensor (i.e. a vector) from an array"
     t = Tensor(I32).from_array([1, 2, 3, 4, 5])
     assert: t.element_count == 5
     assert: t.element_byte_width == I32.byte_width
     assert: t.into_array == [1, 2, 3, 4, 5]
+
+  :it "creates a 0-dimensional tensor (i.e. a scalar) from a single value"
+    t = Tensor(I32).scalar(99)
+    assert: t.element_count == 1
+    assert: t.element_byte_width == I32.byte_width
+    assert: t.into_array == [99]

--- a/src/Tensor.Gen.Random.savi
+++ b/src/Tensor.Gen.Random.savi
@@ -1,0 +1,153 @@
+:: A seeded source of pseudo-randomness, usable by multiple nodes in a graph.
+::
+:: It tracks offsets of each use site internally during graph setup,
+:: so that each node in a graph that uses it will get distinct random results.
+:class Tensor.Gen.Random
+  :let _graph Tensor.Graph
+  :let _name String
+  :let algorithm Tensor.Gen.Random.Algorithm
+
+  // TODO: account for replica ID in a distributed setup, to vary the RNG key
+  // in a predictable way based on the seed plus replica id.
+  :let key Tensor.Graph.CanOutput
+
+  :let _base_counter Tensor.Graph.CanOutput
+
+  :var _next_offset U64: 0
+
+  :new _new(@_graph, @_name, @algorithm, @key, @_base_counter)
+
+  :: Seed a new pseudo-random source in the given graph, with the given seed.
+  ::
+  :: The seed must be a graph node output of type `Tensor(U32)` and shape `[2]`.
+  :fun non new!(
+    graph Tensor.Graph
+    name String
+    seed Tensor.Graph.CanOutput
+    algorithm = Tensor.Gen.Random.Algorithm.Philox
+  )
+    g = Tensor.Graph.Helper.new(graph)
+    case algorithm == (
+    | Tensor.Gen.Random.Algorithm.Philox |
+      // TODO: Try to simplify this once I've got a test case up and running with it.
+      philox_scrambled = Tensor.Op.Random.Uniform.Integers.new!(
+        g.graph, "\(name).seed_scramble"
+        algorithm
+        g.const!("\(name).seed_scramble.const", Tensor(U64).from_array([
+          0x02461e293ec8f720
+        ]))
+        g.cast!("\(name).seed_scramble.cast", seed, Tensor(U64))
+        Tensor(U32)
+        g.const!("\(name).seed_scramble.shape", Tensor(I32).from_array([4]))
+      )
+      philox_key = g.reshape!("\(name).key.reshape"
+        g.bitcast!("\(name).key.bitcast"
+          g.slice!("\(name).key.slice", philox_scrambled, [0], [2])
+          Tensor(U64)
+        )
+        [1]
+      )
+      philox_base_counter = g.pack!("\(name).counter", [
+        g.const!("\(name).counter.zero"
+          Tensor(U64).scalar(0)
+        )
+        g.bitcast!("\(name).counter.bitcast"
+          g.slice!("\(name).counter.slice", philox_scrambled, [2], [2])
+          Tensor(U64)
+        )
+      ])
+
+      @_new(
+        graph
+        name
+        algorithm
+        philox_key
+        philox_base_counter
+      )
+
+    | Tensor.Gen.Random.Algorithm.Threefry |
+      // TODO: Try to simplify this once I've got a test case up and running with it.
+      @_new(
+        graph
+        name
+        algorithm
+        Tensor.Op.Bitcast.new!(g.graph, "\(name).key"
+          Tensor.Op.Cast.new!(g.graph, "\(name).seed.cast"
+            seed
+            Tensor(U32)
+          )
+          Tensor(U64)
+        )
+        Tensor.Op.Const.new!(g.graph, "\(name).counter"
+          Tensor(U64).from_array([0])
+        )
+      )
+    |
+      g.graph.errors << Tensor.Graph.Error.new(
+        Tensor.Graph.Error.Code.InvalidArgument
+        "PRNG algorithm \(algorithm) has no seeding system implemented for it"
+      )
+
+      error!
+    )
+
+  :: Get a counter graph output suitable for use in pseudo-random generation,
+  :: reserving counting space for the given number of elements.
+  ::
+  :: The next time this method is called it will return a higher counter value,
+  :: with each call increasing the counter to a higher offset of the base value.
+  ::
+  :: This is what ensures that different graph nodes that use the same random
+  :: source will get distinct values when generating (but those distinct
+  :: values will still be deterministic based on the seed and graph layout).
+  :fun ref use_counter!(reserve_count U64)
+    g = Tensor.Graph.Helper.new(@_graph)
+
+    // TODO: Why does TensorFlow use 256? Can we justify it explicitly?
+    // TODO: Should it vary with the width of the data type being generated?
+    offset = @_next_offset, @_next_offset += reserve_count * 256
+
+    // If the current offset is zero, we can avoid the below operations
+    // and just return the base counter output directly.
+    return @_base_counter if offset.is_zero
+
+    // Otherwise we're going to create some ops that add the offset.
+    name String = "\(@_name).counter.plus\(offset)"
+    // TODO: Handle overflow for Philox using `select` to choose between
+    // taking `add([0, offset])` or `add([1, offset])` based on whether the
+    // former has a result whose second index is greater than that index
+    // of the original tensor value prior to adding.
+    g.add!(name
+      @_base_counter
+      g.const!("\(name).const"
+        if (@algorithm == Tensor.Gen.Random.Algorithm.Philox) (
+          Tensor(U64).from_array([0, offset])
+        |
+          Tensor(U64).from_array([offset])
+        )
+      )
+    )
+
+:: For parallel pseudo-random number generator algorithms, there are options
+:: to choose from. See the individual member documentation for more information.
+::
+:: Note that efficient parallel pseudo-random number generation (such as when
+:: doing tensor operations on GPUS) calls for a different class of algorithm
+:: than the typical algorithms used in single-threaded CPU contexts.
+:enum Tensor.Gen.Random.Algorithm
+  :: The Philox parallel pseudo-random number generator algorithm.
+  :: See <https://www.thesalmons.org/john/random123/papers/random123sc11.pdf>
+  ::
+  :: In that paper it is benchmarked as significantly outperforming `Threefry`
+  :: on GPUs, while very slightly underperforming it on CPUs.
+  :: As such, we use this as the default in most places with a selectable algo.
+  :member Philox 1
+  :fun non default: Tensor.Gen.Random.Algorithm.Philox
+
+  :: The Threefry parallel pseudo-random number generator algorithm.
+  :: See <https://www.thesalmons.org/john/random123/papers/random123sc11.pdf>
+  ::
+  :: In that paper it is benchmarked as significantly underperforming `Philox`
+  :: on GPUs, while very slightly outperforming it on CPUs.
+  :member Threefry 2
+

--- a/src/Tensor.Graph.Helper.savi
+++ b/src/Tensor.Graph.Helper.savi
@@ -13,6 +13,67 @@
     Tensor.Op.Const.new!(@graph, name, value)
 
   ///
+  // Pseudo-Random Sources
+
+  :fun ref gen_random!(name
+    seed
+    algorithm Tensor.Gen.Random.Algorithm = Tensor.Gen.Random.Algorithm.Philox
+  )
+    Tensor.Gen.Random.new!(@graph, name, seed, algorithm)
+
+  :fun ref random_uniform!(name
+    gen_random Tensor.Gen.Random
+    output_type
+    output_shape Array(USize)
+  )
+    output_shape_tensor = Tensor(I64).generate(output_shape.size) -> (i |
+      output_shape[i]!.i64!
+    )
+    Tensor.Op.Random.Uniform.new!(@graph, name
+      gen_random.algorithm
+      gen_random.key
+      gen_random.use_counter!(output_shape_tensor.element_count.u64)
+      output_type
+      @const!("\(name).output_shape", output_shape_tensor)
+    )
+
+  :fun ref random_uniform_integers!(name
+    gen_random Tensor.Gen.Random
+    output_type
+    output_shape Array(USize)
+  )
+    output_shape_tensor = Tensor(I64).generate(output_shape.size) -> (i |
+      output_shape[i]!.i64!
+    )
+    Tensor.Op.Random.Uniform.Integers.new!(@graph, name
+      gen_random.algorithm
+      gen_random.key
+      gen_random.use_counter!(output_shape_tensor.element_count.u64)
+      output_type
+      @const!("\(name).output_shape", output_shape_tensor)
+    )
+
+  :fun ref random_uniform_bounded_integers!(name
+    gen_random Tensor.Gen.Random
+    output_type
+    output_shape Array(USize)
+    min_val Tensor.Any
+    max_val Tensor.Any
+  )
+    output_shape_tensor = Tensor(I64).generate(output_shape.size) -> (i |
+      output_shape[i]!.i64!
+    )
+    Tensor.Op.Random.Uniform.BoundedIntegers.new!(@graph, name
+      gen_random.algorithm
+      gen_random.key
+      gen_random.use_counter!(output_shape_tensor.element_count.u64)
+      output_type
+      @const!("\(name).output_shape", output_shape_tensor)
+      @const!("\(name).min", min_val)
+      @const!("\(name).max", max_val)
+    )
+
+  ///
   // Logical Operations
 
   :fun ref logical_not!(name, input)
@@ -23,6 +84,12 @@
 
   :fun ref logical_or!(name, x, y)
     Tensor.Op.Logical.Or.new!(@graph, name, x, y)
+
+  ///
+  // Arithmetic Operations
+
+  :fun ref add!(name, x, y)
+    Tensor.Op.Add.new!(@graph, name, x, y)
 
   ///
   // Comparative Operations

--- a/src/Tensor.Graph.Operation.savi
+++ b/src/Tensor.Graph.Operation.savi
@@ -20,7 +20,7 @@
   // This constructor is private so that only Graph can initiate it,
   // that yields the builder to the caller in a controlled way.
   :new _new(@graph, op_type String, oper_name String)
-    @_ptr = @_ffi.new(@graph._ptr, op_type.cpointer, oper_name.cpointer)
+    @_ptr = @_ffi.new(@graph._ptr, op_type.cstring, oper_name.cstring)
 
   :fun ref add_input(can_output Tensor.Graph.CanOutput)
     return @ if @_ptr.is_null

--- a/src/Tensor.Op.Add.savi
+++ b/src/Tensor.Op.Add.savi
@@ -1,0 +1,23 @@
+:: Add each of the values in one input tensor to the corresponding values in
+:: another input tensor to produce an output tensor of sum values.
+::
+:: Both input tensors must have the same shape or broadcast-compatible shapes.
+::
+:: A shape is broadcast-compatible with another shape if its corresponding
+:: dimensions (starting with the inner most) are each equivalent, or 1,
+:: Extra outermost dimensions of size 1 can implicitly be treated as existing
+:: if that helps with aligning with the dimensions of the other shape(s).
+:: When a dimension of size 1 is aligned with a dimension of larger size,
+:: the value of the size-1 dimension will be "broadcast" across all positions
+:: of the wide dimension, such that its value will correspond to many values.
+:: See <https://numpy.org/doc/stable/user/basics.broadcasting.html>
+:struct box Tensor.Op.Add
+  :is Tensor.Op
+
+  :fun non new!(graph Tensor.Graph, name, x, y)
+    @_new(graph.new_operation("AddV2", name) -> (builder |
+      builder
+        .add_input(x)
+        .add_input(y)
+        .finish!
+    ))

--- a/src/Tensor.Op.Random.savi
+++ b/src/Tensor.Op.Random.savi
@@ -1,0 +1,87 @@
+:: Generate pseudo-random floating-point numbers in a uniform distribution,
+:: with values ranging from zero to one.
+::
+:: The given `algorithm` will be used to generate values, using the given
+:: `key` and `counter` values as the state for deterministic generation.
+:: A `Tensor.Gen.Random` instance should typically supply these values.
+:struct box Tensor.Op.Random.Uniform
+  :is Tensor.Op
+
+  :fun non new!(graph Tensor.Graph, name
+    algorithm Tensor.Gen.Random.Algorithm
+    key
+    counter
+    output_type Tensor.Any'non
+    output_shape
+  )
+    @_new(graph.new_operation("StatelessRandomUniformV2", name) -> (builder |
+      builder
+        .add_input(output_shape)
+        .add_input(key)
+        .add_input(counter)
+        .add_input(Tensor.Op.Const.new!(graph, "\(name).algorithm"
+          Tensor(I32).scalar(algorithm.i32)
+        ))
+        .set_attr_type("dtype", output_type.element_type_code)
+        .finish!
+    ))
+
+:: Generate pseudo-random integers in a uniform distribution, with values
+:: across the entire range of values representable by the given integer type.
+::
+:: The given `algorithm` will be used to generate values, using the given
+:: `key` and `counter` values as the state for deterministic generation.
+:: A `Tensor.Gen.Random` instance should typically supply these values.
+:struct box Tensor.Op.Random.Uniform.Integers
+  :is Tensor.Op
+
+  :fun non new!(graph Tensor.Graph, name
+    algorithm Tensor.Gen.Random.Algorithm
+    key
+    counter
+    output_type Tensor.Any'non
+    output_shape
+  )
+    @_new(graph.new_operation("StatelessRandomUniformFullIntV2", name) -> (builder |
+      builder
+        .add_input(output_shape)
+        .add_input(key)
+        .add_input(counter)
+        .add_input(Tensor.Op.Const.new!(graph, "\(name).algorithm"
+          Tensor(I32).scalar(algorithm.i32)
+        ))
+        .set_attr_type("dtype", output_type.element_type_code)
+        .finish!
+    ))
+
+:: Generate pseudo-random integers in a uniform distribution, bounded to a
+:: value range including the given `min_value`, excluding the `max_value`.
+::
+:: The given `algorithm` will be used to generate values, using the given
+:: `key` and `counter` values as the state for deterministic generation.
+:: A `Tensor.Gen.Random` instance should typically supply these values.
+:struct box Tensor.Op.Random.Uniform.BoundedIntegers
+  :is Tensor.Op
+
+  :fun non new!(graph Tensor.Graph, name
+    algorithm Tensor.Gen.Random.Algorithm
+    key
+    counter
+    output_type Tensor.Any'non
+    output_shape
+    min_value
+    max_value
+  )
+    @_new(graph.new_operation("StatelessRandomUniformIntV2", name) -> (builder |
+      builder
+        .add_input(output_shape)
+        .add_input(key)
+        .add_input(counter)
+        .add_input(Tensor.Op.Const.new!(graph, "\(name).algorithm"
+          Tensor(I32).scalar(algorithm.i32)
+        ))
+        .add_input(min_value)
+        .add_input(max_value)
+        .set_attr_type("dtype", output_type.element_type_code)
+        .finish!
+    ))

--- a/src/Tensor.Op.Select.savi
+++ b/src/Tensor.Op.Select.savi
@@ -13,6 +13,7 @@
 :: When a dimension of size 1 is aligned with a dimension of larger size,
 :: the value of the size-1 dimension will be "broadcast" across all positions
 :: of the wide dimension, such that its value will correspond to many values.
+:: See <https://numpy.org/doc/stable/user/basics.broadcasting.html>
 ::
 :struct box Tensor.Op.Select
   :is Tensor.Op

--- a/src/Tensor.savi
+++ b/src/Tensor.savi
@@ -122,7 +122,10 @@
     num_dims.times -> (index | shape << @_ffi.dim_at(@_ptr, index.i32).usize)
     shape
 
-  :fun element_count: _FFI.Tensor.element_count(@_ptr).usize
+  :fun element_count
+    count = _FFI.Tensor.element_count(@_ptr).usize
+    if count.is_zero (USize.one | count)
+
   :fun element_byte_width: T.byte_width
   :fun non element_type_code I32: _FFI.DataType(T).code // TODO: avoid I32 here?
 


### PR DESCRIPTION
These new operations can be used to generate pseudo-random deterministic numbers in a uniform distribution,
using seeded parallel random number generation algorithms.

This commit also adds `Tensor.Op.Add` because it was required to support certain parts of the seeding process.